### PR TITLE
Refactor read macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: required
 
 env:
   matrix:
-    - LISP=sbcl COVERALLS=true
-    - LISP=ccl
+    - LISP=ccl COVERALLS=true
 
 install:
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: required
 
 env:
   matrix:
-    - LISP=ccl COVERALLS=true
+    - LISP=sbcl COVERALLS=true
+    - LISP=ccl
 
 install:
   - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: common-lisp
+sudo: required
+
+env:
+  matrix:
+    - LISP=sbcl COVERALLS=true
+    - LISP=ccl
+
+install:
+  - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | sh;
+
+script:
+  - cl -l cl-locale -l prove -l cl-coveralls
+       -e '(progn
+            (setf prove:*debug-on-error* t
+                  *debugger-hook* (lambda (c h)
+                                    (declare (ignore c h))
+                                    (uiop:quit -1)))
+            (or (coveralls:with-coveralls (:exclude "t")
+                  (prove:run :cl-locale-test))
+                (uiop:quit -1)))'

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,7 @@
 # CL-Locale - Simple i18n library for Common Lisp
+[![Build Status](https://travis-ci.org/fukamachi/cl-locale.svg?branch=master)](https://travis-ci.org/fukamachi/cl-locale)
+[![Coverage Status](https://coveralls.io/repos/fukamachi/cl-locale/badge.svg?branch=master)](https://coveralls.io/r/fukamachi/cl-locale?branch=master)
+
 
 ## Usage
 

--- a/cl-locale-test.asd
+++ b/cl-locale-test.asd
@@ -13,6 +13,7 @@
 
 (defsystem cl-locale-test
   :depends-on (:cl-locale
+               :cl-syntax
                :flexi-streams
                :prove)
   :components ((:module "t"

--- a/cl-locale-test.asd
+++ b/cl-locale-test.asd
@@ -13,10 +13,13 @@
 
 (defsystem cl-locale-test
   :depends-on (:cl-locale
-               :cl-locale-syntax
-               :cl-syntax
-               :cl-test-more
-               :flexi-streams)
+               :flexi-streams
+               :prove)
   :components ((:module "t"
                 :components
-                ((:file "locale")))))
+                ((:file "locale"))))
+  :description "Test system for cl-locale."
+  :defsystem-depends-on (:prove-asdf)
+  :perform (test-op :after (op c)
+                    (funcall (intern #.(string :run-test-system) :prove-asdf) c)
+                    (asdf:clear-system c)))

--- a/cl-locale-test.asd
+++ b/cl-locale-test.asd
@@ -18,7 +18,7 @@
                :prove)
   :components ((:module "t"
                 :components
-                ((:file "locale"))))
+                ((:test-file "locale"))))
   :description "Test system for cl-locale."
   :defsystem-depends-on (:prove-asdf)
   :perform (test-op :after (op c)

--- a/cl-locale.asd
+++ b/cl-locale.asd
@@ -18,7 +18,7 @@
 (in-package :cl-locale-asd)
 
 (defsystem cl-locale
-  :version "0.1"
+  :version "0.1.1"
   :author "Eitarow Fukamachi"
   :depends-on (:anaphora
                :arnesi

--- a/cl-locale.asd
+++ b/cl-locale.asd
@@ -24,7 +24,8 @@
                :arnesi
                :cl-annot
                :cl-syntax
-               :cl-syntax-annot)
+               :cl-syntax-annot
+               :named-readtables)
   :license "LLGPL"
   :components ((:module "src"
                 :components ((:file "locale" :depends-on ("core" "reader"))

--- a/cl-locale.asd
+++ b/cl-locale.asd
@@ -24,13 +24,13 @@
                :arnesi
                :cl-annot
                :cl-syntax
-               :cl-syntax-annot
-               :named-readtables)
+               :cl-syntax-annot)
   :license "LLGPL"
   :components ((:module "src"
-                :components ((:file "locale" :depends-on ("core" "reader"))
+                :components ((:file "locale" :depends-on ("core" "reader" "syntax"))
                              (:file "core")
-                             (:file "reader" :depends-on ("core")))))
+                             (:file "reader" :depends-on ("core"))
+                             (:file "syntax" :depends-on ("reader")))))
   :description "Simple i18n library for Common Lisp"
   :long-description
   #.(with-open-file (stream (merge-pathnames

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -92,7 +92,7 @@ Example:
          params))
 
 @export
-(defun l10n (string &key (locale *locale*) (dictionary (current-dictionary)))
+(defun l18n-unformatted (string &key (locale *locale*) (dictionary (current-dictionary)))
   (aand (not (eq locale *default-locale*))
            (gethash locale dictionary)
            (gethash string arnesi:it)))

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -90,3 +90,9 @@ Example:
                    (gethash string arnesi:it))
              string)
          params))
+
+@export
+(defun l10n (string &keys (locale *locale*) (dictionary (current-dictionary)))
+  (aand (not (eq locale *default-locale*))
+           (gethash locale dictionary)
+           (gethash string arnesi:it)))

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -92,7 +92,7 @@ Example:
          params))
 
 @export
-(defun l10n (string &keys (locale *locale*) (dictionary (current-dictionary)))
+(defun l10n (string &key (locale *locale*) (dictionary (current-dictionary)))
   (aand (not (eq locale *default-locale*))
            (gethash locale dictionary)
            (gethash string arnesi:it)))

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -92,7 +92,7 @@ Example:
          params))
 
 @export
-(defun l18n-unformatted (string &key (locale *locale*) (dictionary (current-dictionary)))
+(defun i18n-unformatted (string &key (locale *locale*) (dictionary (current-dictionary)))
   (aand (not (eq locale *default-locale*))
            (gethash locale dictionary)
            (gethash string arnesi:it)))

--- a/src/locale.lisp
+++ b/src/locale.lisp
@@ -19,6 +19,7 @@
            :define-dictionary
            :current-dictionary
            :i18n
+           :l10n
            :enable-locale-syntax
            :locale-syntax
            :i18n-reader

--- a/src/locale.lisp
+++ b/src/locale.lisp
@@ -20,4 +20,6 @@
            :current-dictionary
            :i18n
            :enable-locale-syntax
-           :locale-syntax))
+           :locale-syntax
+           :i18n-reader
+           :l10n-reader))

--- a/src/locale.lisp
+++ b/src/locale.lisp
@@ -12,6 +12,7 @@
         :cl-locale.core
         :cl-locale.reader
         :cl-locale.syntax)
+  (:nicknames :locale)
   (:export :*default-locale*
            :*locale*
            :*dictionary-tables*

--- a/src/locale.lisp
+++ b/src/locale.lisp
@@ -18,4 +18,5 @@
            :define-dictionary
            :current-dictionary
            :i18n
-           :enable-locale-syntax))
+           :enable-locale-syntax
+           :cl-locale-readtable))

--- a/src/locale.lisp
+++ b/src/locale.lisp
@@ -19,8 +19,8 @@
            :define-dictionary
            :current-dictionary
            :i18n
-           :l10n
+           :i18n-unformatted
            :enable-locale-syntax
            :locale-syntax
            :i18n-reader
-           :l10n-reader))
+           :i18n-unformatted-reader))

--- a/src/locale.lisp
+++ b/src/locale.lisp
@@ -10,7 +10,8 @@
 (defpackage cl-locale
   (:use :cl
         :cl-locale.core
-        :cl-locale.reader)
+        :cl-locale.reader
+        :cl-locale.syntax)
   (:export :*default-locale*
            :*locale*
            :*dictionary-tables*
@@ -19,4 +20,4 @@
            :current-dictionary
            :i18n
            :enable-locale-syntax
-           :cl-locale-readtable))
+           :locale-syntax))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -15,7 +15,8 @@
 
 (use-syntax :annot)
 
-(defun locale-syntax-reader (stream char numarg)
+@export
+(defun i18n-reader (stream char numarg)
   (declare (ignore char numarg))
   (let ((ch (peek-char t stream))
         (args (read stream)))
@@ -24,13 +25,14 @@
       (#\( `(i18n ,(car args) :params (list ,@(cdr args))))
       (t (error "i18n reader must precede a list or a double-quoted string.: ~A" ch)))))
 
+@export
 (defun l10n-reader (stream char numarg)
   (declare (ignore char numarg))
   `(l10n ,(read stream)))
 
 (defun %enable-locale-syntax ()
   (setf *readtable* (copy-readtable))
-  (set-dispatch-macro-character #\# #\i #'locale-syntax-reader)
+  (set-dispatch-macro-character #\# #\i #'i18n-reader)
   (set-dispatch-macro-character #\# #\l #'l10n-reader))
 
 @export

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -10,7 +10,10 @@
 (defpackage cl-locale.reader
   (:use :cl
         :cl-syntax
-        :cl-locale.core))
+        :cl-locale.core)
+  (:import-from :named-readtables
+                :defreadtable)
+  (:export cl-locale-readtable))
 (in-package :cl-locale.reader)
 
 (use-syntax :annot)
@@ -32,3 +35,7 @@
 (defmacro enable-locale-syntax ()
   '(eval-when (:compile-toplevel :load-toplevel :execute)
     (%enable-locale-syntax)))
+
+(defreadtable cl-locale-readtable
+  (:merge :standard)
+  (:dispatch-macro-char #\# #\i #'locale-syntax-reader))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -24,9 +24,14 @@
       (#\( `(i18n ,(car args) :params (list ,@(cdr args))))
       (t (error "i18n reader must precede a list or a double-quoted string.: ~A" ch)))))
 
+(defun l10n-reader (stream char numarg)
+  (declare (ignore char numarg))
+  `(l10n ,(read stream)))
+
 (defun %enable-locale-syntax ()
   (setf *readtable* (copy-readtable))
-  (set-dispatch-macro-character #\# #\i #'locale-syntax-reader))
+  (set-dispatch-macro-character #\# #\i #'locale-syntax-reader)
+  (set-dispatch-macro-character #\# #\l #'l10n-reader))
 
 @export
 (defmacro enable-locale-syntax ()

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -26,7 +26,7 @@
 
 (defun %enable-locale-syntax ()
   (setf *readtable* (copy-readtable))
-  (set-macro-character #\@ #'locale-syntax-reader))
+  (set-dispatch-macro-character #\# #\i #'locale-syntax-reader))
 
 @export
 (defmacro enable-locale-syntax ()

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -26,14 +26,14 @@
       (t (error "i18n reader must precede a list or a double-quoted string.: ~A" ch)))))
 
 @export
-(defun l10n-reader (stream char numarg)
+(defun i18n-unformatted-reader (stream char numarg)
   (declare (ignore char numarg))
-  `(l10n ,(read stream)))
+  `(i18n-unformatted-reader ,(read stream)))
 
 (defun %enable-locale-syntax ()
   (setf *readtable* (copy-readtable))
   (set-dispatch-macro-character #\# #\i #'i18n-reader)
-  (set-dispatch-macro-character #\# #\l #'l10n-reader))
+  (set-dispatch-macro-character #\# #\l #'i18n-unformatted-reader))
 
 @export
 (defmacro enable-locale-syntax ()

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -10,10 +10,7 @@
 (defpackage cl-locale.reader
   (:use :cl
         :cl-syntax
-        :cl-locale.core)
-  (:import-from :named-readtables
-                :defreadtable)
-  (:export cl-locale-readtable))
+        :cl-locale.core))
 (in-package :cl-locale.reader)
 
 (use-syntax :annot)
@@ -35,7 +32,3 @@
 (defmacro enable-locale-syntax ()
   '(eval-when (:compile-toplevel :load-toplevel :execute)
     (%enable-locale-syntax)))
-
-(defreadtable cl-locale-readtable
-  (:merge :standard)
-  (:dispatch-macro-char #\# #\i #'locale-syntax-reader))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -15,28 +15,14 @@
 
 (use-syntax :annot)
 
-(defun read-lisp-string (input)
-  "Parse a Lisp string. Expects “input” to point to the
-  first character after the leading double quote.
-  Slick version by Xach."
-  (with-output-to-string (output)
-    (loop
-      (let ((char (read-char input)))
-        (case char
-          (#\\
-           (setf char (read-char input)))
-          (#\"
-           (return)))
-        (write-char char output)))))
-
-(defun locale-syntax-reader (stream char arg)
-  (declare (ignore arg char))
-  (let ((ch (read-char stream)))
-  (case ch
-    (#\" `(i18n ,(read-lisp-string stream)))
-    (#\( (let ((body (read-delimited-list #\) stream)))
-           `(i18n ,(car body) :params (list ,@(cdr body)))))
-    (t (error "i18n reader must precede a list or a double-quoted string.: ~A" ch)))))
+(defun locale-syntax-reader (stream char numarg)
+  (declare (ignore char numarg))
+  (let ((ch (peek-char t stream))
+        (args (read stream)))
+    (case ch
+      (#\" `(i18n ,args))
+      (#\( `(i18n ,(car args) :params (list ,@(cdr args))))
+      (t (error "i18n reader must precede a list or a double-quoted string.: ~A" ch)))))
 
 (defun %enable-locale-syntax ()
   (setf *readtable* (copy-readtable))

--- a/src/syntax.lisp
+++ b/src/syntax.lisp
@@ -11,11 +11,11 @@
   (:use :cl)
   (:import-from :cl-locale.reader
                 :i18n-reader
-                :l10n-reader)
+                :i18n-unformatted-reader)
   (:export :locale-syntax))
 (in-package :cl-locale.syntax)
 
 (syntax:defsyntax locale-syntax
   (:merge :standard)
   (:dispatch-macro-char #\# #\i #'i18n-reader)
-  (:dispatch-macro-char #\# #\l #'l10n-reader))
+  (:dispatch-macro-char #\# #\l #'i18n-unformatted-reader))

--- a/src/syntax.lisp
+++ b/src/syntax.lisp
@@ -16,4 +16,5 @@
 
 (syntax:defsyntax locale-syntax
   (:merge :standard)
-  (:dispatch-macro-char #\# #\i #'locale-syntax-reader))
+  (:dispatch-macro-char #\# #\i #'locale-syntax-reader)
+  (:dispatch-macro-char #\# #\l #'l10n-reader))

--- a/src/syntax.lisp
+++ b/src/syntax.lisp
@@ -10,11 +10,12 @@
 (defpackage cl-locale.syntax
   (:use :cl)
   (:import-from :cl-locale.reader
-                :locale-syntax-reader)
+                :i18n-reader
+                :l10n-reader)
   (:export :locale-syntax))
 (in-package :cl-locale.syntax)
 
 (syntax:defsyntax locale-syntax
   (:merge :standard)
-  (:dispatch-macro-char #\# #\i #'locale-syntax-reader)
+  (:dispatch-macro-char #\# #\i #'i18n-reader)
   (:dispatch-macro-char #\# #\l #'l10n-reader))

--- a/src/syntax.lisp
+++ b/src/syntax.lisp
@@ -10,7 +10,8 @@
 (defpackage cl-locale.syntax
   (:use :cl)
   (:import-from :cl-locale.reader
-                :locale-syntax-reader))
+                :locale-syntax-reader)
+  (:export :locale-syntax))
 (in-package :cl-locale.syntax)
 
 (syntax:defsyntax locale-syntax

--- a/src/syntax.lisp
+++ b/src/syntax.lisp
@@ -7,12 +7,12 @@
 |#
 
 (in-package :cl-user)
-(defpackage cl-locale-syntax
+(defpackage cl-locale.syntax
   (:use :cl)
   (:import-from :cl-locale.reader
                 :locale-syntax-reader))
-(in-package :cl-locale-syntax)
+(in-package :cl-locale.syntax)
 
-(syntax:define-package-syntax :cl-locale
+(syntax:defsyntax locale-syntax
   (:merge :standard)
   (:dispatch-macro-char #\# #\i #'locale-syntax-reader))

--- a/t/i18n/fr_FR.lisp
+++ b/t/i18n/fr_FR.lisp
@@ -1,1 +1,2 @@
-(("Lisping" . "Zézaiement"))
+(("Lisping" . "Zézaiement")
+ ("date-format" . (:day "-" :month "-" :year)))

--- a/t/i18n/ja_JP.lisp
+++ b/t/i18n/ja_JP.lisp
@@ -1,2 +1,3 @@
 (("Lisping" . "舌足らず")
- ("~A Lisp" . "~A りすぷ"))
+ ("~A Lisp" . "~A りすぷ")
+ ("date-format" . (:year "." :month "." :day)))

--- a/t/locale.lisp
+++ b/t/locale.lisp
@@ -2,12 +2,11 @@
 (defpackage cl-locale-test
   (:use :cl
         :cl-locale
-        ;;:cl-locale-syntax
-        ;;:cl-syntax
+        :cl-syntax
         :prove))
 (in-package :cl-locale-test)
 
-(named-readtables:in-readtable cl-locale-readtable)
+(use-syntax :locale-syntax)
 
 (plan 8)
 

--- a/t/locale.lisp
+++ b/t/locale.lisp
@@ -8,22 +8,28 @@
 
 (named-readtables:in-readtable locale-syntax)
 
-(plan 8)
+(plan 13)
 
 (setf *dictionary-tables* (make-hash-table :test 'equal))
 (setf *locale* :en-US)
 
 (define-dictionary schedule
-  (:ja-JP '(("Schedule" . "予定")))
-  (:fr-FR '(("Schedule" . "Calendrier"))))
+  (:ja-JP '(("Schedule" . "予定")
+            ("date-format" . (:year "." :month "." :day))))
+  (:fr-FR '(("Schedule" . "Calendrier")
+            ("date-format" . (:day "-" :month "-" :year)))))
 
 (is (i18n "Schedule") "Schedule" "en-US (default locale)")
 
 (setf *locale* :ja-JP)
 
 (is (i18n "Schedule") "予定" "ja-JP (default locale)")
-(is (i18n "Schedule" :locale :ja-JP) "予定" "ja-JP")
-(is (i18n "Schedule" :locale :fr-FR) "Calendrier" "fr-FR")
+(is (i18n "Schedule" :locale :ja-JP) "予定" "ja-JP i18n")
+(is (i18n "Schedule" :locale :fr-FR) "Calendrier" "fr-FR i18n")
+
+(is (l10n "date-format") '(:year "." :month "." :day))
+(is (l10n "date-format" :locale :ja-JP) '(:year "." :month "." :day) "ja-JP l10n")
+(is (l10n "date-format" :locale :fr-FR) '(:day "-" :month "-" :year) "fr-FR l10n")
 
 (define-dictionary lisp
   (:ja-JP (asdf:system-relative-pathname
@@ -35,11 +41,18 @@
 
 (let ((jp-mean
        (flex:octets-to-string #(232 136 140 232 182 179 227 130 137 227 129 154)
-        :external-format :utf-8)))
+        :external-format :utf-8))
+      (jp-format '(:year "." :month "." :day)))
   (is (i18n "Lisping" :locale :ja-JP)
       jp-mean
-      "load from file")
-  (is #i"Lisping" jp-mean "with reader macro"))
+      "i18n load from file")
+  (is #i"Lisping" jp-mean "i18n with reader macro")
+
+  (is (l10n "date-format" :locale :ja-JP)
+      jp-format
+      "l10n load from file")
+  (is #l"date-format" jp-format "l10n with reader macro"))
+
 (let ((jp-mean
        (flex:octets-to-string #(67 111 109 109 111 110 32 227 130 138 227 129 153 227 129 183)
         :external-format :utf-8)))

--- a/t/locale.lisp
+++ b/t/locale.lisp
@@ -2,9 +2,9 @@
 (defpackage cl-locale-test
   (:use :cl
         :cl-locale
-        :cl-locale-syntax
-        :cl-syntax
-        :cl-test-more))
+        ;;:cl-locale-syntax
+        ;;:cl-syntax
+        :prove))
 (in-package :cl-locale-test)
 
 (named-readtables:in-readtable cl-locale-readtable)

--- a/t/locale.lisp
+++ b/t/locale.lisp
@@ -6,7 +6,7 @@
         :prove))
 (in-package :cl-locale-test)
 
-(use-syntax :locale-syntax)
+(named-readtables:in-readtable locale-syntax)
 
 (plan 8)
 

--- a/t/locale.lisp
+++ b/t/locale.lisp
@@ -7,7 +7,7 @@
         :cl-test-more))
 (in-package :cl-locale-test)
 
-(use-syntax locale-syntax)
+(named-readtables:in-readtable cl-locale-readtable)
 
 (plan 8)
 

--- a/t/locale.lisp
+++ b/t/locale.lisp
@@ -27,9 +27,9 @@
 (is (i18n "Schedule" :locale :ja-JP) "予定" "ja-JP i18n")
 (is (i18n "Schedule" :locale :fr-FR) "Calendrier" "fr-FR i18n")
 
-(is (l10n "date-format") '(:year "." :month "." :day))
-(is (l10n "date-format" :locale :ja-JP) '(:year "." :month "." :day) "ja-JP l10n")
-(is (l10n "date-format" :locale :fr-FR) '(:day "-" :month "-" :year) "fr-FR l10n")
+(is (i18n-unformatted "date-format") '(:year "." :month "." :day))
+(is (i18n-unformatted "date-format" :locale :ja-JP) '(:year "." :month "." :day) "ja-JP i18n-unformatted")
+(is (i18n-unformatted "date-format" :locale :fr-FR) '(:day "-" :month "-" :year) "fr-FR i18n-unformatted")
 
 (define-dictionary lisp
   (:ja-JP (asdf:system-relative-pathname
@@ -48,10 +48,10 @@
       "i18n load from file")
   (is #i"Lisping" jp-mean "i18n with reader macro")
 
-  (is (l10n "date-format" :locale :ja-JP)
+  (is (i18n-unformatted "date-format" :locale :ja-JP)
       jp-format
-      "l10n load from file")
-  (is #l"date-format" jp-format "l10n with reader macro"))
+      "i18n-unformatted load from file")
+  (is #l"date-format" jp-format "i18n-unformatted with reader macro"))
 
 (let ((jp-mean
        (flex:octets-to-string #(67 111 109 109 111 110 32 227 130 138 227 129 153 227 129 183)


### PR DESCRIPTION
Some improvements:
1. The `enable-locale-syntax` was using a differente macro character
2. With `#'peek-char` the custom string-reading function is obselete. Also it doesn't throw the error when there is a space between the `i` and the `"`, like in `#i "xxx"`.
3. Added the `syntax.lisp` file to the `cl-locale.asd`
4. Added a description to the test system and `prove-asdf` stuff.
5. Added Travis and Coveralls badge to README.

Travis fails because the SBCL version from cl-travis isn't friendly with `@export` directives. Should I remove them?

CCL tests [pass](https://travis-ci.org/EuAndreh/cl-locale/jobs/72040327), though.

I was also thinking in adding a `l10n` function. It would be similar to `i18n`, but wouldn't `apply #'format nil` to the given argument:

``` lisp
(defun l10n (string &keys (locale *locale*) (dictionary (current-dictionary)))
  (aand (not (eq locale *default-locale*))
           (gethash locale dictionary)
           (gethash string arnesi:it)))
```

It would be useful for formatting dates and times, for example:

``` lisp
;; pt.lisp
(("Schedule" . "Calendrier")
 ("date" . (:day "/" :month "/" :year))

(local-time:format-timestring nil (local-time:now) :format (l10n "date"))
```

Also, a read-macro for it:

``` lisp
(defun l10n-reader (stream char numarg)
  (declare (ignore char numarg))
  `(l10n ,(read stream)))
```

What do you think about that?
