### PR TITLE
Add :in-order-to and fix #l reader-macro

### DIFF
--- a/cl-locale.asd
+++ b/cl-locale.asd
@@ -44,4 +44,4 @@
                                :fill-pointer t)))
           (setf (fill-pointer seq) (read-sequence seq stream))
           seq)))
-  :in-order-to ((test-op (load-op cl-locale-test))))
+  :in-order-to ((test-op (test-op cl-locale-test))))

--- a/cl-locale.asd
+++ b/cl-locale.asd
@@ -43,4 +43,5 @@
                                :element-type 'character
                                :fill-pointer t)))
           (setf (fill-pointer seq) (read-sequence seq stream))
-          seq))))
+          seq)))
+  :in-order-to ((test-op (load-op cl-locale-test))))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -28,7 +28,7 @@
 @export
 (defun i18n-unformatted-reader (stream char numarg)
   (declare (ignore char numarg))
-  `(i18n-unformatted-reader ,(read stream)))
+  `(i18n-unformatted ,(read stream)))
 
 (defun %enable-locale-syntax ()
   (setf *readtable* (copy-readtable))


### PR DESCRIPTION
Added `:in-order-to` in asdf file (to allow `(asdf:test-system :cl-locale)`) and fixed the form that `#l` expands to from `(i18n-unformatted-reader ...` to `(i18n-unformatted ...)`.

Just a few things missing from last PR.
